### PR TITLE
Fixed SMB Check

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -61,6 +61,7 @@ install_package python3-dev
 install_package freerdp2-x11
 install_package smbclient
 install_package nginx
+CRYPTOGRAPHY_DONT_BUILD_RUST=1
 pip3 install -U dnspython pysmb paramiko requests timeout-decorator toml pycryptodome
 pip3 install -U Flask flask_login flask-wtf bcrypt uwsgi
 


### PR DESCRIPTION
Switched over to the pysmb module, both anonymous and file check for SMB now works. Previous issue seemed to be with Samba users, but issue should now be resolved using the SMBConnection class from pysmb.