### PR TITLE
Fixed error with FTP check in README, bug with datetime in server.py and  added troubleshooting steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,12 @@ points = 500
 - The solution is to `chown` everything.
  - `chown -R www-data:www-data /opt/minos`
 
+**502 Bad Gateway**
+- This may occur when the configuration file fails to be read from the /opt/minos/engine/running-config.cfg file. To fix this you may run `cp /opt/minos/config.cfg /opt/minos/engine/running-config.cfg` to fix this.
+
+**Scoring engine backend is not running**
+- You may get this error when you open up the dashboard status page. This can be fixed by adding `running = 1` in the settings section of the configuration.
+
 ## Contributing and Disclaimer
 
 If you have anything you would like to add or fix, please make a pull request! No improvement or fix is too small, and help is always appreciated.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ tolerance = 50 # Difference tolerance, default 20%
 ```
 [systems.systemname.ftp]
 port = 1234 # Default 21
-file = "cool_bug_facts.txt" # File to retrieve
+path = "cool_bug_facts.txt" # File to retrieve
 hash = "9bb6c1dc2408ee6cb09778ca2ac6abad91de9be4 " # sha1 hash of the file
 file = "systemname.html" # Local checkfile to compare with
 ```

--- a/engine/server.py
+++ b/engine/server.py
@@ -3,9 +3,9 @@ from flask_login import LoginManager, current_user, login_user, logout_user, log
 from flask import Flask, render_template, request, redirect, url_for, send_file
 from urllib.parse import urlparse, urljoin
 from decorators import admin_required
-from datetime import datetime, timedelta
 from web import *
 from forms import *
+from datetime import datetime, timedelta
 from io import BytesIO
 import engine
 import flask


### PR DESCRIPTION
### Error With FTP check in README
It seems like the 2 paths in the README were incorrect. I checked the source and corrected it to what I believe is correct.

### Bug with datetime in server.py
On line 29 in engine/server.py I was getting an error that datetime.now() did not exist but it appeared that due to an update or something similar, the form library was overriding the normal datetime. Moving it down a bit on the import list seemed to fix the issue for me.

### Added Troubleshooting Steps
I was unable to grab any screenshots of the bugs as I was unable to reproduce the errors but I have added the steps that I was able to take to reproduce them. If I am able to reproduce them, I will add pictures.

Sorry about the 2 pull requests, it is my first time doing a public pull request.